### PR TITLE
Revert "Build Docker image for ARM"

### DIFF
--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -76,6 +76,7 @@ jobs:
         with:
           context: .
           target: slurmctld
+          platforms: linux/amd64
           push: true
           build-args: |
             DOCKER_METADATA_OUTPUT_JSON
@@ -101,6 +102,7 @@ jobs:
         with:
           context: .
           target: slurmdbd
+          platforms: linux/amd64
           push: true
           build-args: |
             DOCKER_METADATA_OUTPUT_JSON

--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -37,9 +37,6 @@ jobs:
           username: ${{ env.REGISTRY_USER }}
           password: ${{ env.REGISTRY_PASSWORD }}
 
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@988b5a0280414f521da01fcc63a27aeeb4b104db
-
       - name: Build packager
         uses: docker/build-push-action@91df6b874e498451163feb47610c87c4a218c1ee
         with:
@@ -67,19 +64,12 @@ jobs:
           images: ${{ env.IMAGE_REGISTRY }}/${{ env.IMAGE_NAME }}
           flavor: |
             suffix=-slurmctld
-          tags: |
-            type=schedule
-            type=ref,event=branch
-            type=ref,event=tag
-            type=ref,event=pr
-            type=sha,format=long
 
       - name: Build and push slurmctld image
         uses: docker/build-push-action@91df6b874e498451163feb47610c87c4a218c1ee
         with:
           context: .
           target: slurmctld
-          platforms: linux/amd64,linux/arm64
           push: true
           build-args: |
             DOCKER_METADATA_OUTPUT_JSON
@@ -93,19 +83,12 @@ jobs:
           images: ${{ env.IMAGE_REGISTRY }}/${{ env.IMAGE_NAME }}
           flavor: |
             suffix=-slurmdbd
-          tags: |
-            type=schedule
-            type=ref,event=branch
-            type=ref,event=tag
-            type=ref,event=pr
-            type=sha,format=long
 
       - name: Build and push slurmdbd image
         uses: docker/build-push-action@91df6b874e498451163feb47610c87c4a218c1ee
         with:
           context: .
           target: slurmdbd
-          platforms: linux/amd64,linux/arm64
           push: true
           build-args: |
             DOCKER_METADATA_OUTPUT_JSON

--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -64,6 +64,12 @@ jobs:
           images: ${{ env.IMAGE_REGISTRY }}/${{ env.IMAGE_NAME }}
           flavor: |
             suffix=-slurmctld
+          tags: |
+            type=schedule
+            type=ref,event=branch
+            type=ref,event=tag
+            type=ref,event=pr
+            type=sha,format=long
 
       - name: Build and push slurmctld image
         uses: docker/build-push-action@91df6b874e498451163feb47610c87c4a218c1ee
@@ -83,6 +89,12 @@ jobs:
           images: ${{ env.IMAGE_REGISTRY }}/${{ env.IMAGE_NAME }}
           flavor: |
             suffix=-slurmdbd
+          tags: |
+            type=schedule
+            type=ref,event=branch
+            type=ref,event=tag
+            type=ref,event=pr
+            type=sha,format=long
 
       - name: Build and push slurmdbd image
         uses: docker/build-push-action@91df6b874e498451163feb47610c87c4a218c1ee


### PR DESCRIPTION
Reverts WATonomous/slurm-dist#2

ARM builds increases the build time from 5 minutes to almost an hour.
We don't have any ARM machines in the on-prem cluster. We can reapply this in the future if needed.